### PR TITLE
Cluster support

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,13 +5,23 @@ FROM jboss/base-jdk:8
 ENV INFINISPAN_SERVER_HOME /opt/jboss/infinispan-server
 
 # Set the INFINISPAN_VERSION env variable
-ENV INFINISPAN_VERSION 8.2.0.Final
+ENV INFINISPAN_VERSION 9.0.0.Alpha3
 
-# Download and unzip Infinispan server
-RUN cd $HOME && curl http://downloads.jboss.org/infinispan/$INFINISPAN_VERSION/infinispan-server-$INFINISPAN_VERSION-bin.zip | bsdtar -xf - && mv $HOME/infinispan-server-$INFINISPAN_VERSION $HOME/infinispan-server && chmod +x /opt/jboss/infinispan-server/bin/standalone.sh
+ENV MGMT_USER admin
+
+ENV MGMT_PASS admin
+
+# Server download location
+ENV DISTRIBUTION_URL https://repo1.maven.org/maven2/org/infinispan/server/infinispan-server-build/$INFINISPAN_VERSION/infinispan-server-build-$INFINISPAN_VERSION.zip
+
+# Download and extract the Infinispan Server
+RUN INFINISPAN_SHA=$(curl $DISTRIBUTION_URL.sha1); curl -o /tmp/server.zip $DISTRIBUTION_URL && sha1sum /tmp/server.zip | grep $INFINISPAN_SHA \
+    && unzip -q /tmp/server.zip -d $HOME && mv $HOME/infinispan-server-* $HOME/infinispan-server && rm /tmp/server.zip
+
+# Copy entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin
+
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 # Expose Infinispan server  ports 
-EXPOSE 8080 8181 9990 11211 11222 
-
-# Run Infinispan server and bind to all interface
-CMD ["/opt/jboss/infinispan-server/bin/standalone.sh", "-b", "0.0.0.0"]
+EXPOSE 7600 8080 8181 9990 11211 11222 57600

--- a/server/README.md
+++ b/server/README.md
@@ -1,13 +1,69 @@
 # Infinispan server Docker image
 
-Infinispan Server
-=================
+## Starting in clustered mode
 
-This is an example Dockerfile with [Infinispan](http://infinispan.org/) server.
-
-## Usage
+Run one or more:
 
     docker run -it jboss/infinispan-server
+
+and the containers should be able to form a cluster.
+
+#### Choosing the JGroups stack
+
+To run with the ```tcp``` stack instead of ```udp```:
+
+    docker run -it jboss/infinispan-server -Djboss.default.jgroups.stack=tcp
+
+The run with the ```tcp-gossip``` stack, specifying the router location:
+
+    docker run -it jboss/infinispan-server -Djboss.default.jgroups.stack=tcp-gossip -Djgroups.gossip.initial_hosts=172.17.0.2[12001]
+
+## Starting in standalone mode
+
+    docker run -it jboss/infinispan-server standalone
+
+As it happens with clustered mode, it is possible to specify command line parameters to the server.
+
+Examples:
+
+To avoid exposing the management interface:
+
+    docker run -it jboss/infinispan-server standalone -Djboss.bind.address.management=127.0.0.1
+
+To print the version and exit:
+
+    docker run -it jboss/infinispan-server standalone -v
+
+Please consult the Infinispan user docs to find out about the available options.  
+
+## Starting with a custom configuration
+
+The first param to the container is the name of the desired configuration. For example, to start with the ```cloud.xml``` configuration:
+
+    docker run -it jboss/infinispan-server cloud -Djboss.default.jgroups.stack=google -Djgroups.google.bucket=... -Djgroups.google.access_key=... 
+
+## Configuring authentication
+   
+The 'default' and 'standalone' running modes don't not have credentials set. In order to define them, run after launching the container:
+
+    docker exec -it $(docker ps -l -q) /opt/jboss/infinispan-server/bin/add-user.sh
+
+and follow the instructions.
+
+## Running domain mode
+
+Domain mode is composed of a lightweight managing process that does not hold data called domain controller plus one or more
+host controllers co-located with the Infinispan Server nodes. To run the domain controller:
+
+    docker run --name=dc -it jboss/infinispan-server domain-controller 
+
+And then each host controller can be started as:
+
+    docker run --link dc:dc -it jboss/infinispan-server host-controller
+
+### Acessing the Server Management Console
+
+The Server Management Console listens on the domain controller on port 9990. Credentials are admin/admin.
 
 ## Extending the image
 

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+BIND=$(hostname -i)
+SERVER=/opt/jboss/infinispan-server
+LAUNCHER=$SERVER/bin/standalone.sh
+CONFIG=clustered
+BIND_OPTS="-Djboss.bind.address.management=0.0.0.0 -Djgroups.join_timeout=1000 -Djgroups.bind_addr=$BIND -Djboss.bind.address=$BIND"
+
+if [ "$1" = 'domain-controller' ]
+then
+  shift;
+  $SERVER/bin/add-user.sh -u $MGMT_USER -p $MGMT_PASS
+  LAUNCHER=$SERVER/bin/domain.sh
+  exec $LAUNCHER --host-config host-master.xml $BIND_OPTS "$@"
+elif [ "$1" = 'host-controller' ]
+then
+  shift;
+  LAUNCHER=$SERVER/bin/domain.sh
+  BASE=$(echo -n $MGMT_USER | base64) && sed -i "s/\<secret value=.*/secret value=\"$BASE\" \/>/" $SERVER/domain/configuration/host-slave.xml
+  sed -i  "s/\(remote security-realm=\"ManagementRealm\"\)/\1 username=\"$MGMT_USER\"/" $SERVER/domain/configuration/host-slave.xml
+  exec $LAUNCHER --host-config host-slave.xml -Djboss.domain.master.address=$DC_PORT_9990_TCP_ADDR $BIND_OPTS "$@"
+else
+  if [ $# -ne 0 ] && [ -f $SERVER/standalone/configuration/$1.xml ]; then CONFIG=$1; shift; fi
+  exec $LAUNCHER -c $CONFIG.xml $BIND_OPTS "$@"
+fi
+


### PR DESCRIPTION
Add support for clustering in the image plus other small changes:

* Update to Infinispan 9.0.0.Alpha3.
   Can we tag master in order to build 9.x images and create another branch for 8.2.x ?

* Extract using unzip instead of bsdtar to preserve file permissions
* Add entrypoint script to support running clustered mode besides standalone
* Support to pass parameters to the server in order to choose the JGroups stack
* Support for domain mode
* Added usage instructions