### PR TITLE
ISPN-6890 Infinispan server can not start with Openshift

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -11,12 +11,28 @@ ENV MGMT_USER admin
 
 ENV MGMT_PASS admin
 
+# Ensure signals are forwarded to the JVM process correctly for graceful shutdown
+ENV LAUNCH_JBOSS_IN_BACKGROUND true
+
 # Server download location
 ENV DISTRIBUTION_URL https://repo1.maven.org/maven2/org/infinispan/server/infinispan-server-build/$INFINISPAN_VERSION/infinispan-server-build-$INFINISPAN_VERSION.zip
 
 # Download and extract the Infinispan Server
 RUN INFINISPAN_SHA=$(curl $DISTRIBUTION_URL.sha1); curl -o /tmp/server.zip $DISTRIBUTION_URL && sha1sum /tmp/server.zip | grep $INFINISPAN_SHA \
     && unzip -q /tmp/server.zip -d $HOME && mv $HOME/infinispan-server-* $HOME/infinispan-server && rm /tmp/server.zip
+
+# For Openshift
+USER root
+
+RUN chgrp -R 0 /opt/jboss/infinispan-server/
+
+RUN chmod -R g+rw /opt/jboss/infinispan-server/
+
+RUN find /opt/jboss/infinispan-server/ -type d -exec chmod g+x {} +
+
+ENV HOME /opt/jboss/
+
+USER 1000
 
 # Copy entrypoint script
 COPY docker-entrypoint.sh /usr/local/bin


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6890

Test worked on Openshift master:
```
oc v1.3.0-alpha.0-676-ge65adfa-dirty
kubernetes v1.3.0-alpha.1-331-g0522e63
```

Could not test on earlier versions due to environmental issues: the Vagrant based setup has docker version 1.9 and it fails to pull images out of the Dockerhub, that is compatible only with Docker 1.10+