### PR TITLE
Bump to Infinispan 8.2.5.Final

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,7 +5,7 @@ FROM jboss/base-jdk:8
 ENV INFINISPAN_SERVER_HOME /opt/jboss/infinispan-server
 
 # Set the INFINISPAN_VERSION env variable
-ENV INFINISPAN_VERSION 8.2.4.Final
+ENV INFINISPAN_VERSION 8.2.5.Final
 
 ENV MGMT_USER admin
 


### PR DESCRIPTION
Just a version upgrade.

Is there a specific reason why wildfly-modules Dockerfile is still at 8.2.3.Final and not at 8.2.4.Final?

If you think is good I can make a PR for update Wildfly-modules too.

Thanks