### PR TITLE
infinispan version updated from 9.0.0.Beta2 to 9.0.0.CR1

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,7 +5,7 @@ FROM jboss/base-jdk:8
 ENV INFINISPAN_SERVER_HOME /opt/jboss/infinispan-server
 
 # Set the INFINISPAN_VERSION env variable
-ENV INFINISPAN_VERSION 9.0.0.Beta2
+ENV INFINISPAN_VERSION 9.0.0.CR1
 
 ENV MGMT_USER admin
 


### PR DESCRIPTION
Dockerfile edited to update the Infinispan version from from 9.0.0.Beta2 to 9.0.0.CR1