### PR TITLE
Automatic releases

### DIFF
--- a/Jenkinsfile-release
+++ b/Jenkinsfile-release
@@ -1,0 +1,33 @@
+#!/usr/bin/env groovy
+
+pipeline {
+    agent {
+        label 'slave-group-release'
+    }
+
+    parameters {
+        string(defaultValue: '9.3.0.Beta1', description: 'Release version', name: 'version')
+        string(defaultValue: 'master', description: 'Release branch', name: 'branch')
+        string(defaultValue: 'true', description: 'Dry run', name: 'dryRun')
+        string(defaultValue: 'false', description: 'Skip tests', name: 'skipTests')
+    }
+
+    options {
+        timeout(time: 3, unit: 'HOURS')
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm
+                sh "git checkout ${branch}"
+            }
+        }
+
+        stage('Version') {
+            steps {
+                sh "make RELEASE_NAME=${version} DRY_RUN=${dryRun} SKIP_TESTS=${skipTests} PUSH_ORIGIN=origin release"
+            }
+        }
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+RELEASE_NAME=9.2.3.Final
+DRY_RUN=true
+PUSH_ORIGIN=origin
+SKIP_TESTS=false
+
+_replace_version_in_dockerfile:
+	sed -i "s/ENV INFINISPAN_VERSION.*/ENV INFINISPAN_VERSION $(RELEASE_NAME)/g" ./server/Dockerfile
+.PHONY: _replace_version_in_dockerfile
+
+_commit_changes:
+	git commit -a -m "$(RELEASE_NAME) upgrade"
+.PHONY: _commit_changes
+
+_test:
+ifeq ($(SKIP_TESTS), false)
+	cd ci && ./ci_check.sh
+	cd ci && ./ci_openshift.sh
+else
+	$(info SKIP_TESTS is set to true. Skipping...)
+endif
+.PHONY: _test
+
+_tag_changes:
+	git tag "$(RELEASE_NAME)"
+.PHONY: _tag_changes
+
+_push_changes:
+ifeq ($(DRY_RUN), false)
+	git push $(PUSH_ORIGIN)
+else
+	$(info DRY_RUN is set to true. Skipping...)
+endif
+.PHONY: _push_changes
+
+release: _replace_version_in_dockerfile _test _commit_changes _tag_changes _push_changes
+.PHONY: release
+
+


### PR DESCRIPTION
This is the initial version of the script. 

The targets starting from `_` are not completed automatically by Bash nor ZSH completion. So think about them as of private ones.

This script is very easy to be automated. All you need is to invoke it like this:

```
make RELEASE_NAME=9.2.3.Final DRY_RUN=false PUSH_ORIGIN=upstream release
```