### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -195,7 +195,7 @@ RUN_TYPE='STANDALONE'
 CONTAINER_SETTINGS="true"
 SERVER_OPTIONS=""
 SERVER_CONFIGURATION="clustered.xml"
-JAVA_OPTS="-Djava.net.preferIPv4Stack=true -XX:+DisableExplicitGC"
+JAVA_OPTS="-Djava.net.preferIPv4Stack=true -XX:+DisableExplicitGC -Djboss.modules.system.pkgs=org.jboss.byteman,org.jboss.logmanager.LogManager"
 PERCENT_OF_MEMORY_FOR_MX=50
 
 for i in "$@"


### PR DESCRIPTION
Right now `docker run -m 1024M <img> --jmx` fails with Log Manager complains.